### PR TITLE
Added configuration for scope for structures, ADTs and templates

### DIFF
--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ADT.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ADT.java
@@ -8,6 +8,8 @@ import org.osgi.framework.Bundle;
 public interface ADT {
     /**
      * Creates a new ADT if it an adt with this key does not exist, or updates it if it does exist.
+     * @param siteKey   The String siteKey that will be used to place the ADT in the right side.
+     *                  If not provided the ADT will be placed in default space.
      * @param adtKey    The String adtkey that will be used to identify this adt
      * @param fileUrl   The String relative url of the ADT script
      * @param bundle    The Bundle containing the ADT script file
@@ -16,6 +18,6 @@ public interface ADT {
      * @param nameMap   The Map<Locale, String> containing the locale & titles of the ADT
      * @param descriptionMap    The Map<Locale, String> containing the locale & descriptions of the ADT
      */
-    void createOrUpdateADT(String adtKey,String fileUrl, Bundle bundle, String className,
+    void createOrUpdateADT(String siteKey, String adtKey,String fileUrl, Bundle bundle, String className,
                     Map<Locale, String> nameMap, Map<Locale, String> descriptionMap);
 }

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ADTImpl.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ADTImpl.java
@@ -37,18 +37,19 @@ public class ADTImpl implements ADT{
     private ClassNameLocalService classNameLocalService;
     @Reference
     private DefaultValue defaultValue;
-
+    @Reference
+     private ScopeHelper scopeHelper;
 
     protected DDMTemplateLocalService ddmTemplateLocalService;
 
     protected DDMTemplateVersionLocalService ddmTemplateVersionLocalService;
 
     @Override
-    public void createOrUpdateADT(String adtKey,String fileUrl, Bundle bundle, String className, Map<Locale, String> nameMap,
+    public void createOrUpdateADT(String siteKey, String adtKey,String fileUrl, Bundle bundle, String className, Map<Locale, String> nameMap,
                     Map<Locale, String> descriptionMap) {
         long resourceClassNameId = classNameLocalService.getClassNameId("com.liferay.portlet.display.template.PortletDisplayTemplate");
         long classNameId = classNameLocalService.getClassNameId(className);
-        long groupId = defaultValue.getGlobalGroupId();
+        long groupId = scopeHelper.getGroupIdByName(siteKey);
         DDMTemplate adt = getADT(adtKey, groupId, classNameId);
         if (Validator.isNull(adt)) {
             LOG.info(String.format("ADT %s does not exist, creating ADT",adtKey));

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ScopeHelper.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ScopeHelper.java
@@ -1,0 +1,12 @@
+package nl.finalist.liferay.lam.api;
+
+public interface ScopeHelper {
+    /**
+     * Method will return group id that is associated with the given site name. If a match
+     * is not found the default group ID is returned.
+     *
+     * @param siteKey Group (Site) name
+     * @return given group id or default group id
+     */
+    long getGroupIdByName(String siteKey);
+}

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ScopeHelperImpl.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/ScopeHelperImpl.java
@@ -1,0 +1,26 @@
+package nl.finalist.liferay.lam.api;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.Validator;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class ScopeHelperImpl implements ScopeHelper {
+
+    @Reference
+    private DefaultValue defaultValue;
+
+    @Reference
+    private GroupLocalService groupService;
+
+    @Override
+    public long getGroupIdByName(String siteKey) {
+        Group site = null;
+        if (!Validator.isBlank(siteKey)) {
+            site = groupService.fetchGroup(defaultValue.getDefaultCompany().getCompanyId(), siteKey);
+        }
+        return site != null ? site.getGroupId() : defaultValue.getGlobalGroupId();
+    }
+}

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/Structure.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/Structure.java
@@ -8,11 +8,14 @@ import org.osgi.framework.Bundle;
 public interface Structure {
     /**
      * Creates or updates a structure if it already exists.
+     *
+     * @param siteKey   The String siteKey that will be used to place the ADT in the right side.
+     *                  If not provided the ADT will be placed in default space.
      * @param structureKey The string structurekey of the structure which will be used for further identifying purposes
      * @param fileUrl The String relative url to the Structure json file
      * @param bundle The Bundle containing the json structure file
      * @param nameMap   The Map<Locale, String> nameMap containing the localized titles of the structure
      * @param descriptionMap    The Map<Locale, String> descriptionMap containing the localized descriptions of the structure
      */
-    void createOrUpdateStructure(String structureKey, String fileUrl, Bundle bundle, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap);
+    void createOrUpdateStructure(String siteKey, String structureKey, String fileUrl, Bundle bundle, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap);
 }

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/StructureImpl.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/StructureImpl.java
@@ -45,11 +45,13 @@ public class StructureImpl implements Structure {
     private DDMStructureVersionLocalService ddmStructureVersionLocalService;
     @Reference
     private DefaultValue defaultValue;
+    @Reference
+    private ScopeHelper scopeHelper;
 
     @Override
-    public void createOrUpdateStructure(String structureKey, String fileUrl, Bundle bundle, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap){
+    public void createOrUpdateStructure(String siteKey,String structureKey, String fileUrl, Bundle bundle, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap){
         long classNameId = classNameLocalService.getClassNameId(JournalArticle.class.getName());
-        long groupId = defaultValue.getGlobalGroupId();
+        long groupId = scopeHelper.getGroupIdByName(siteKey);
         DDMStructure structure = getStructure(structureKey, groupId, classNameId);
         if(Validator.isNull(structure)){
             LOG.info(String.format("Structure %s does not exist, creating structure", structureKey));

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/Template.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/Template.java
@@ -8,6 +8,9 @@ import org.osgi.framework.Bundle;
 public interface Template {
     /**
      * Creates a Web Content template or updates it if it does not exist yest
+     *
+     * @param siteKey   The String siteKey that will be used to place the ADT in the right side.
+     *                  If not provided the ADT will be placed in default space.
      * @param templateKey The String templateKey that will be used as an identifier
      * @param fileUrl   The String relative url to the file containing the template script
      * @param bundle    The Bundle containing the template script file
@@ -15,5 +18,5 @@ public interface Template {
      * @param nameMap The Map<Locale, String> nameMap containing the localized titles of the template
      * @param descriptionMap The Map<Locale, String> description containing the localized descriptions of the template
      */
-    void createOrUpdateTemplate(String templateKey, String fileUrl, Bundle bundle, String structureKey, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap);
+    void createOrUpdateTemplate(String siteKey,String templateKey, String fileUrl, Bundle bundle, String structureKey, Map<Locale, String> nameMap, Map<Locale, String> descriptionMap);
 }

--- a/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/TemplateImpl.java
+++ b/nl.finalist.liferay.lam.api/src/main/java/nl/finalist/liferay/lam/api/TemplateImpl.java
@@ -39,12 +39,15 @@ public class TemplateImpl extends ADTImpl implements Template {
     @Reference
     private DDMStructureLocalService ddmStructureLocalService;
 
+    @Reference
+    private ScopeHelper scopeHelper;
+
     @Override
-    public void createOrUpdateTemplate(String adtKey, String fileUrl, Bundle bundle, String structureKey, Map<Locale, String> nameMap,
+    public void createOrUpdateTemplate(String siteKey,String adtKey, String fileUrl, Bundle bundle, String structureKey, Map<Locale, String> nameMap,
                     Map<Locale, String> descriptionMap) {
         long resourceClassNameId = classNameLocalService.getClassNameId(JournalArticle.class.getName());
         long classNameId = classNameLocalService.getClassNameId(DDMStructure.class.getName());
-        long groupId = defaultValue.getGlobalGroupId();
+        long groupId = scopeHelper.getGroupIdByName(siteKey);
         long classPK = getClassPk(structureKey, groupId, resourceClassNameId);
         DDMTemplate adt = getADT(adtKey, groupId, classNameId);
         if (Validator.isNull(adt)) {

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateADTFactory.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateADTFactory.groovy
@@ -28,6 +28,6 @@ class CreateOrUpdateADTFactory extends AbstractFactory {
         ADTModel model = (ADTModel) node;
         
       
-        adtService.createOrUpdateADT(model.adtKey, model.file, bundle ,model.type, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
+        adtService.createOrUpdateADT(model.siteKey, model.adtKey, model.file, bundle ,model.type, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
     }
 }

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateStructureFactory.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateStructureFactory.groovy
@@ -25,6 +25,6 @@ class CreateOrUpdateStructureFactory extends AbstractFactory {
         StructureModel model = (StructureModel) node;
         
       
-        structureService.createOrUpdateStructure(model.structureKey, model.file, bundle, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
+        structureService.createOrUpdateStructure(model.siteKey, model.structureKey, model.file, bundle, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
     }
 }

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateTemplateFactory.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/builder/factory/CreateOrUpdateTemplateFactory.groovy
@@ -27,6 +27,6 @@ class CreateOrUpdateTemplateFactory extends AbstractFactory {
         TemplateModel model = (TemplateModel) node;
         
       
-        templateService.createOrUpdateTemplate(model.templateKey, model.file, bundle ,model.forStructure, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
+        templateService.createOrUpdateTemplate(model.siteKey, model.templateKey, model.file, bundle ,model.forStructure, LocaleMapConverter.convert(model.nameMap), LocaleMapConverter.convert(model.descriptionMap));
     }
 }

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/ADTModel.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/ADTModel.groovy
@@ -1,7 +1,7 @@
 package nl.finalist.liferay.lam.dslglue.model;
 
 class ADTModel {
-
+    String siteKey
   	String file
 	String type
 	Map<String, String> nameMap

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/StructureModel.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/StructureModel.groovy
@@ -1,5 +1,6 @@
 package nl.finalist.liferay.lam.dslglue.model
 class StructureModel {
+	String siteKey
 	String file
 	Map<String, String> nameMap
 	Map<String, String> descriptionMap

--- a/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/TemplateModel.groovy
+++ b/nl.finalist.liferay.lam.dslglue/src/main/groovy/nl/finalist/liferay/lam/dslglue/model/TemplateModel.groovy
@@ -1,5 +1,6 @@
 package nl.finalist.liferay.lam.dslglue.model
 class TemplateModel {
+	String siteKey
 	String file
 	String forStructure
 	Map<String, String> nameMap


### PR DESCRIPTION
Hi

I added an optional group identification for the structures, templates and ADTs. This way the structures can be placed into another scopes not only global.

If the site name can not be resolved it will fallback to global.